### PR TITLE
chore: add CNAME for retro-pilot.adnankhan.me

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+retro-pilot.adnankhan.me


### PR DESCRIPTION
## Summary
Adds `docs/CNAME` with the value `retro-pilot.adnankhan.me` so GitHub Pages serves this site at the custom subdomain.

## Prerequisite
Matching DNS CNAME record must exist:

```
retro-pilot.adnankhan.me -> adnanafik.github.io
```

Once DNS propagates, old URLs (`adnanafik.github.io/retro-pilot` and `adnankhan.me/retro-pilot/`) automatically 301-redirect to the new subdomain.

## Test plan
- [ ] DNS record added (external, not part of this PR)
- [ ] GitHub Pages settings show green DNS check after propagation
- [ ] Enforce HTTPS toggle enabled in Pages settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)